### PR TITLE
Add trait bounds for Abomonation automatically

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -68,7 +68,7 @@ mod tests {
     }
 
     #[derive(Eq, PartialEq, Abomonation)]
-    pub struct GenericStruct<T: ::abomonation::Abomonation, U: ::abomonation::Abomonation>(T, u64, U);
+    pub struct GenericStruct<T, U>(T, u64, U);
 
     #[test]
     fn test_generic_struct() {


### PR DESCRIPTION
This change allows generic structs to be defined without trait bounds on the struct itself. The bounds required for the implementation of `Abomonation` will be added automatically as where clauses to it.