### PR TITLE
Fix broken generic trait bounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub fn derive_abomonation(input: TokenStream) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let where_clause_complete = add_bounds(where_clause, &ast.generics.ty_params);
+    println!("{:?}", where_clause_complete);
     let result = quote! {
         impl #impl_generics ::abomonation::Abomonation for #name #ty_generics
             #where_clause_complete
@@ -64,9 +65,10 @@ pub fn derive_abomonation(input: TokenStream) -> TokenStream {
 }
 
 fn add_bounds(where_clause: &syn::WhereClause, ty_params: &[syn::TyParam]) -> quote::Tokens {
+    let idents = ty_params.iter().map(|ty_param| &ty_param.ident);
     if where_clause.predicates.is_empty() {
-        quote! { where #(#ty_params: ::abomonation::Abomonation),* }
+        quote! { where #(#idents: ::abomonation::Abomonation),* }
     } else {
-        quote! { #where_clause #(, #ty_params: ::abomonation::Abomonation)* }
+        quote! { #where_clause #(, #idents: ::abomonation::Abomonation)* }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ pub fn derive_abomonation(input: TokenStream) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let where_clause_complete = add_bounds(where_clause, &ast.generics.ty_params);
-    println!("{:?}", where_clause_complete);
     let result = quote! {
         impl #impl_generics ::abomonation::Abomonation for #name #ty_generics
             #where_clause_complete

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -133,4 +133,13 @@ mod tests {
             assert!(rest.len() == 0);
         }
     }
+
+    pub trait SomeTrait {}
+
+    #[allow(dead_code)]
+    #[derive(Abomonation)]
+    pub enum GenericEnumWithBounds<T: SomeTrait> {
+        A(T),
+        B
+    }
 }


### PR DESCRIPTION
Looks like I introduced a regression in #3, sorry for only realizing that now, after it has been merged already.

When there is already a trait bound on an enum or struct, the generated where-clause is broken, because it just quotes the entire type parameter declaration including bounds like this: `T: SomeTrait: ::abomonation::Abomonation`. Now it is fixed to only use the identifier instead. Added a (compile-only) test case for this.