### PR TITLE
Fix warning about unused mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub fn derive_abomonation(input: TokenStream) -> TokenStream {
             #[inline] unsafe fn embalm(&mut self) {
                 match *self { #embalm }
             }
+            #[allow(unused_mut)]
             #[inline] unsafe fn exhume<'a,'b>(&'a mut self, mut bytes: &'b mut [u8])
                                               -> Option<&'b mut [u8]> {
                 match *self { #exhume }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+#![deny(unused_mut)]
+
 #[macro_use]
 extern crate abomonation_derive;
 extern crate abomonation;


### PR DESCRIPTION
For field-less structs and enums, the mutability of `bytes` in `exhume`
is warned about. This is inconvenient for users, as they have to
annotate the struct with an `#[allow(unused_mut)` lint. The issue only
occurred using the nightly Rust compiler.

This change simply annotates the exhume method like that, so that the
warning is no longer shown to users. To prevent regressions `unused_mut`
is now a hard error in the test module.