### PR TITLE
Updated for abomonation 0_5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ quote = "0.3"
 synstructure = "0.6"
 
 [dev-dependencies]
-abomonation = "0.4"
+abomonation = { git = "https://github.com/frankmcsherry/abomonation" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,7 @@ fn derive_abomonation(mut s: synstructure::Structure) -> quote::Tokens {
 
     let exhume = s.each(|bi| quote! {
         let temp = bytes;
-        let exhume_result = ::abomonation::Abomonation::exhume(#bi, temp);
-        bytes = exhume_result?;
+        bytes = ::abomonation::Abomonation::exhume(#bi, temp)?;
     });
 
     s.bound_impl("::abomonation::Abomonation", quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ extern crate quote;
 decl_derive!([Abomonation] => derive_abomonation);
 
 fn derive_abomonation(mut s: synstructure::Structure) -> quote::Tokens {
-
     let entomb = s.each(|bi| quote! {
         ::abomonation::Abomonation::entomb(#bi, _write)?;
     });
@@ -20,8 +19,7 @@ fn derive_abomonation(mut s: synstructure::Structure) -> quote::Tokens {
 
     let exhume = s.each(|bi| quote! {
         let temp = bytes;
-        let exhume_result = ::abomonation::Abomonation::exhume(#bi, temp);
-        bytes = exhume_result?;
+        let bytes ::abomonation::Abomonation::exhume(#bi, temp)?;
     });
 
     s.bound_impl("::abomonation::Abomonation", quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,31 +7,33 @@ extern crate quote;
 decl_derive!([Abomonation] => derive_abomonation);
 
 fn derive_abomonation(mut s: synstructure::Structure) -> quote::Tokens {
+
     let entomb = s.each(|bi| quote! {
-        ::abomonation::Abomonation::entomb(#bi, _writer);
+        ::abomonation::Abomonation::entomb(#bi, _write)?;
+    });
+
+    let extent = s.each(|bi| quote! {
+        sum += ::abomonation::Abomonation::extent(#bi);
     });
 
     s.bind_with(|_| synstructure::BindStyle::RefMut);
-    let embalm = s.each(|bi| quote! {
-        ::abomonation::Abomonation::embalm(#bi);
-    });
 
     let exhume = s.each(|bi| quote! {
         let temp = bytes;
         let exhume_result = ::abomonation::Abomonation::exhume(#bi, temp);
-        bytes = if let Some(bytes) = exhume_result {
-            bytes
-        } else {
-            return None
-        };
+        bytes = exhume_result?;
     });
 
     s.bound_impl("::abomonation::Abomonation", quote! {
-        #[inline] unsafe fn entomb(&self, _writer: &mut Vec<u8>) {
+        #[inline] unsafe fn entomb<W: ::std::io::Write>(&self, _write: &mut W) -> ::std::io::Result<()> {
             match *self { #entomb }
+            Ok(())
         }
-        #[inline] unsafe fn embalm(&mut self) {
-            match *self { #embalm }
+        #[allow(unused_mut)]
+        #[inline] fn extent(&self) -> usize {
+            let mut sum = 0;
+            match *self { #extent }
+            sum
         }
         #[allow(unused_mut)]
         #[inline] unsafe fn exhume<'a,'b>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ fn derive_abomonation(mut s: synstructure::Structure) -> quote::Tokens {
 
     let exhume = s.each(|bi| quote! {
         let temp = bytes;
-        let bytes ::abomonation::Abomonation::exhume(#bi, temp)?;
+        let exhume_result = ::abomonation::Abomonation::exhume(#bi, temp);
+        bytes = exhume_result?;
     });
 
     s.bound_impl("::abomonation::Abomonation", quote! {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -22,7 +22,9 @@ mod tests {
 
         // encode vector into a Vec<u8>
         let mut bytes = Vec::new();
-        unsafe { encode(&record, &mut bytes); }
+        unsafe { encode(&record, &mut bytes).unwrap(); }
+
+        assert_eq!(bytes.len(), measure(&record));
 
         // decode from binary data
         if let Some((result, rest)) = unsafe { decode::<Struct>(&mut bytes) } {
@@ -41,7 +43,9 @@ mod tests {
 
         // encode vector into a Vec<u8>
         let mut bytes = Vec::new();
-        unsafe { encode(&record, &mut bytes); }
+        unsafe { encode(&record, &mut bytes).unwrap(); }
+
+        assert_eq!(bytes.len(), measure(&record));
 
         // decode from binary data
         if let Some((result, rest)) = unsafe { decode::<EmptyStruct>(&mut bytes) } {
@@ -60,7 +64,9 @@ mod tests {
 
         // encode vector into a Vec<u8>
         let mut bytes = Vec::new();
-        unsafe { encode(&record, &mut bytes); }
+        unsafe { encode(&record, &mut bytes).unwrap(); }
+
+        assert_eq!(bytes.len(), measure(&record));
 
         // decode from binary data
         if let Some((result, rest)) = unsafe { decode::<TupleStruct>(&mut bytes) } {
@@ -79,7 +85,9 @@ mod tests {
 
         // encode vector into a Vec<u8>
         let mut bytes = Vec::new();
-        unsafe { encode(&record, &mut bytes); }
+        unsafe { encode(&record, &mut bytes).unwrap(); }
+
+        assert_eq!(bytes.len(), measure(&record));
 
         // decode from binary data
         if let Some((result, rest)) = unsafe { decode::<GenericStruct<String, Vec<u8>>>(&mut bytes) } {
@@ -103,7 +111,9 @@ mod tests {
 
         // encode vector into a Vec<u8>
         let mut bytes = Vec::new();
-        unsafe { encode(&record, &mut bytes); }
+        unsafe { encode(&record, &mut bytes).unwrap(); }
+
+        assert_eq!(bytes.len(), measure(&record));
 
         // decode from binary data
         if let Some((result, rest)) = unsafe { decode::<BasicEnum>(&mut bytes) } {
@@ -127,7 +137,9 @@ mod tests {
 
         // encode vector into a Vec<u8>
         let mut bytes = Vec::new();
-        unsafe { encode(&record, &mut bytes); }
+        unsafe { encode(&record, &mut bytes).unwrap(); }
+
+        assert_eq!(bytes.len(), measure(&record));
 
         // decode from binary data
         if let Some((result, rest)) = unsafe { decode::<DataEnum>(&mut bytes) } {


### PR DESCRIPTION
This PR introduce some changes that track changes to the `Abomonation` trait in its proposed 0.5 version. These changes are 1. removal of the `embalm` method for address sanitization, 2. introduction of the `extent` method reporting the number of bytes required to serialize the data.

The tests are updated to unwrap the results of `encode` (it now returns a result reflecting the results of writing) and to test that the encoded lengths are the same as reported by `measure` (the method calling in to `extent`).

Importantly, version 0.5 isn't up on crates.io yet, so this PR changes the dev-dependency to point at the abomonation repository. This PR can just chill out until until 0.5 stabilizes a bit more, if you like. I have a fork of the repo that I can keep in sync with 0.5 as it wobbles around, and perhaps return here when there is more confidence that the changes have settled down (I'm not aware of changes that are needed, but there could be issues that get shaken out).