### PR TITLE
Introduce `unsafe_abomonate_ignore` attribute.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,10 @@ extern crate synstructure;
 #[macro_use]
 extern crate quote;
 
-decl_derive!([Abomonation, attributes(abomonate_ignore)] => derive_abomonation);
+decl_derive!([Abomonation, attributes(unsafe_abomonate_ignore)] => derive_abomonation);
 
 fn derive_abomonation(mut s: synstructure::Structure) -> quote::Tokens {
-    s.filter(|bi| !bi.ast().attrs.iter().any(|attr| attr.name() == "abomonate_ignore"));
+    s.filter(|bi| !bi.ast().attrs.iter().any(|attr| attr.name() == "unsafe_abomonate_ignore"));
     
     let entomb = s.each(|bi| quote! {
         ::abomonation::Abomonation::entomb(#bi, _write)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@ extern crate synstructure;
 #[macro_use]
 extern crate quote;
 
-decl_derive!([Abomonation] => derive_abomonation);
+decl_derive!([Abomonation, attributes(abomonate_ignore)] => derive_abomonation);
 
 fn derive_abomonation(mut s: synstructure::Structure) -> quote::Tokens {
+    s.filter(|bi| !bi.ast().attrs.iter().any(|attr| attr.name() == "abomonate_ignore"));
+    
     let entomb = s.each(|bi| quote! {
         ::abomonation::Abomonation::entomb(#bi, _write)?;
     });

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -156,4 +156,13 @@ mod tests {
         A(T),
         B
     }
+
+    pub struct NonAbomonable { }
+
+    #[allow(dead_code)]
+    #[derive(Abomonation)]
+    pub struct StructWithPhantomMarker {
+        data: usize,
+        #[abomonate_ignore] _phantom: ::std::marker::PhantomData<NonAbomonable>,
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -157,12 +157,29 @@ mod tests {
         B
     }
 
-    pub struct NonAbomonable { }
 
-    #[allow(dead_code)]
-    #[derive(Abomonation)]
-    pub struct StructWithPhantomMarker {
-        data: usize,
-        #[abomonate_ignore] _phantom: ::std::marker::PhantomData<NonAbomonable>,
+    #[test]
+    fn test_ignore_attribute() {
+
+        #[derive(Abomonation)]
+        pub struct StructWithPhantomMarker<T> {
+            data: usize,
+            #[unsafe_abomonate_ignore] 
+            _phantom: ::std::marker::PhantomData<T>,
+        }
+
+        struct NonAbomonable { };
+
+        // create some test data with a phantom non-abomonable type.
+        let record = StructWithPhantomMarker {
+            data: 0,
+            _phantom: ::std::marker::PhantomData::<NonAbomonable>,
+        };
+
+        // encode vector into a Vec<u8>
+        let mut bytes = Vec::new();
+        unsafe { encode(&record, &mut bytes).unwrap(); }
+
+        assert_eq!(bytes.len(), measure(&record));
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -157,7 +157,6 @@ mod tests {
         B
     }
 
-
     #[test]
     fn test_ignore_attribute() {
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -164,6 +164,7 @@ mod tests {
         #[derive(Abomonation)]
         pub struct StructWithPhantomMarker<T> {
             data: usize,
+            // test fails to built without this attribute.
             #[unsafe_abomonate_ignore] 
             _phantom: ::std::marker::PhantomData<T>,
         }


### PR DESCRIPTION
This PR introduces an `unsafe_abomonate_ignore` attribute that can be placed on struct fields and which should exclude them from abomonation implementations (these fields will not be chased for `entomb`, nor repopulated in `exhume`).

The attribute is prefixed with `unsafe_` to re-inforce that excluding fields from abomonation implementations can result in UB if the fields with owned data are not correctly repopulated in `decode`.

I don't know if or how the attribute applies to enum variants; any information here would be great!