### PR TITLE
Upgrade to Rust 2018 and bump dependencies accordingly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,17 @@ description = "A custom derive plugin for abomonation"
 license = "MIT"
 repository = "https://github.com/mystor/abomonation_derive"
 documentation = "https://docs.rs/abomonation_derive"
+edition = "2018"
 
 [lib]
 name = "abomonation_derive"
 proc-macro = true
 
 [dependencies]
-syn = "0.11"
-quote = "0.3"
-synstructure = "0.6"
+proc-macro2 = "0.4"
+syn = "0.15"
+quote = "0.6"
+synstructure = "0.10"
 
 [dev-dependencies]
 abomonation = "0.5"


### PR DESCRIPTION
The crate was using a sufficiently old version of syn that the macro
would panic if it was used on a struct that contained a `crate::` path.
Upgrading to the latest version of syn fixes the issue; see the enclosed
test.

For good measure, this commit also upgrades to the latest version of
quote, which in turn requires introducing a dependency on proc_macro2,
and synstructure, and bumps the edition of the crate to Rust 2018.

This is part of a push to upgrade Timely and Differential to Rust 2018.