### PR TITLE
Upgrade proc-macro2, quote, and synstructure dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,9 @@ name = "abomonation_derive"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "0.4"
-syn = "0.15"
-quote = "0.6"
-synstructure = "0.10"
+proc-macro2 = "1.0"
+quote = "1.0"
+synstructure = "0.12"
 
 [dev-dependencies]
 abomonation = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ fn derive_abomonation(mut s: synstructure::Structure) -> proc_macro2::TokenStrea
         !bi.ast().attrs.iter()
             .map(|attr| attr.parse_meta())
             .filter_map(Result::ok)
-            .any(|attr| attr.name() == "unsafe_abomonate_ignore")
+            .any(|attr| attr.path().is_ident("unsafe_abomonate_ignore"))
     });
 
     let entomb = s.each(|bi| quote! {


### PR DESCRIPTION
This patch updates the proc-macro2, quote, and synstructure dependencies
to more recent versions. The former two crates, in particular, have
reached 1.0 versions which are used by an increasing amount of other
crates in the ecosystem and so going with the flow can reduce the number
of crates effectively pulled in during compilation.
The dependency to syn is removed completely, as it is not used.

----

I am not really sure whether there is testing required in addition to running the contained test suite. The only other "tests" I ran was to compile `timely-dataflow/communication` with the new version and `differential-dataflow` (both consume the crate but I did not check much more).