### PR TITLE
Use fully qualified constructor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ fn derive_abomonation(mut s: synstructure::Structure) -> proc_macro2::TokenStrea
     s.bound_impl(quote!(abomonation::Abomonation), quote! {
         #[inline] unsafe fn entomb<W: ::std::io::Write>(&self, _write: &mut W) -> ::std::io::Result<()> {
             match *self { #entomb }
-            Ok(())
+            ::std::io::Result::Ok(())
         }
         #[allow(unused_mut)]
         #[inline] fn extent(&self) -> usize {
@@ -43,9 +43,9 @@ fn derive_abomonation(mut s: synstructure::Structure) -> proc_macro2::TokenStrea
         #[inline] unsafe fn exhume<'a,'b>(
             &'a mut self,
             mut bytes: &'b mut [u8]
-        ) -> Option<&'b mut [u8]> {
+        ) -> ::std::option::Option<&'b mut [u8]> {
             match *self { #exhume }
-            Some(bytes)
+            ::std::option::Option::Some(bytes)
         }
     })
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -167,7 +167,7 @@ mod tests {
             _phantom: ::std::marker::PhantomData<T>,
         }
 
-        struct NonAbomonable { };
+        struct NonAbomonable { }
 
         // create some test data with a phantom non-abomonable type.
         let record = StructWithPhantomMarker {


### PR DESCRIPTION
```rust
use abomonation_derive::Abomonation;
use anyhow::*;

#[derive(Abomonation)]
struct MyType {
    a: u32,
}
```
This code doesn't compile cause anyhow have a method [Ok](https://docs.rs/anyhow/latest/anyhow/fn.Ok.html) which overwrite `std::io::Result::Ok`, this PR disambiguate these by using fully qualified constructor.